### PR TITLE
refactor: code review for PR8

### DIFF
--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -91,13 +91,13 @@ pub async fn summarize_messages_with_check(
 
   if check {
     let trimmed = response.trim();
-    if trimmed.starts_with("CREATE:") {
-      let summary = trimmed.strip_prefix("CREATE:").unwrap_or(trimmed).trim();
+    if let Some(summary) = trimmed.strip_prefix("CREATE:") {
+      let summary = summary.trim();
       if !summary.is_empty() {
         Ok(Some(summary.to_string()))
       } else {
-        // If summary is empty after CREATE:, still create but use full response
-        Ok(Some(trimmed.to_string()))
+        // If the summary is empty, it's better to treat it as a skip
+        Ok(None)
       }
     } else {
       // SKIP or any other response means don't create


### PR DESCRIPTION
## Summary
- Fix stale job detection in event segmentation to prevent duplicate processing
- Treat empty summaries after `CREATE:` as `SKIP` to avoid storing meaningless content
- Move `job.messages` directly into `EpisodicMemory` to avoid cloning large vectors

Based on Gemini's bots' RNs.
https://github.com/moeru-ai/plast-mem/pull/8
 